### PR TITLE
tools:releasetools:Use timestamp from build.prop while building syste…

### DIFF
--- a/tools/releasetools/build_image.py
+++ b/tools/releasetools/build_image.py
@@ -220,7 +220,6 @@ def BuildImage(in_dir, prop_dict, out_file,
   build_command = []
   fs_type = prop_dict.get("fs_type", "")
   run_fsck = False
-
   is_verity_partition = "verity_block_device" in prop_dict
   verity_supported = prop_dict.get("verity") == "true"
   # adjust the partition size to make room for the hashes if this is to be verified
@@ -248,6 +247,22 @@ def BuildImage(in_dir, prop_dict, out_file,
       build_command.extend(["-j", prop_dict["journal_size"]])
     if "timestamp" in prop_dict:
       build_command.extend(["-T", str(prop_dict["timestamp"])])
+    else:
+      #Timestamp not provided in property_dict.
+      #Lets try to find the build.prop file and get the timestamp from there
+      #instead
+      path = in_dir + "/build.prop"
+      if os.path.exists(path):
+        with open(path) as f:
+          lines = f.readlines()
+          for line in lines:
+            line = line.strip()
+            if line.startswith("ro.build.date.utc"):
+              name, value = line.split("=", 1)
+              print "read ro.build.date.utc from build.prop as ", value
+              build_command.extend(["-T", value])
+      else:
+        print "unable to open build.prop file..Image will be built using system time"
     if fs_config is not None:
       build_command.extend(["-C", fs_config])
     if block_list is not None:


### PR DESCRIPTION
…m.img

We now use the timestamp written by the build system to build.prop as the
value passed to the make_ext4fs tool while generating the regular system
image. The ota package generation tools do it already. Without this change
the system image created by a normal make will never match the system image
in the target files package which would cause incremental block based ota's
to fail

Change-Id: I95c32c7ff9c2330a264853014a33811ca5ee3fe4